### PR TITLE
chore(deps): bump @pagefind/default-ui in /apps/documentation

### DIFF
--- a/apps/documentation/package-lock.json
+++ b/apps/documentation/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.3",
         "@astrojs/starlight": "^0.26.1",
+        "@astrojs/starlight-tailwind": "^2.0.3",
         "@astrojs/tailwind": "^5.1.0",
         "astro": "^4.10.2",
         "sharp": "^0.32.5",
@@ -212,6 +213,16 @@
       },
       "peerDependencies": {
         "astro": "^4.8.6"
+      }
+    },
+    "node_modules/@astrojs/starlight-tailwind": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight-tailwind/-/starlight-tailwind-2.0.3.tgz",
+      "integrity": "sha512-ZwbdXS/9rxYlo3tKZoTZoBPUnaaqek02b341dHwOkmMT0lIR2w+8k0mRUGxnRaYtPdMcaL+nYFd8RUa8sjdyRg==",
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.9.0",
+        "@astrojs/tailwind": "^5.0.0",
+        "tailwindcss": "^3.3.3"
       }
     },
     "node_modules/@astrojs/tailwind": {
@@ -1515,9 +1526,9 @@
       ]
     },
     "node_modules/@pagefind/default-ui": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.1.0.tgz",
-      "integrity": "sha512-+XiAJAK++C64nQcD7s3Prdmd5S92lT05fwjOxm0L1jj80jbL+tmvcqkkFnPpoqhnicIPgcAX/Y5W0HRZnBt35w=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.1.1.tgz",
+      "integrity": "sha512-ZM0zDatWDnac/VGHhQCiM7UgA4ca8jpjA+VfuTJyHJBaxGqZMQnm4WoTz9E0KFcue1Bh9kxpu7uWFZfwpZZk0A=="
     },
     "node_modules/@pagefind/linux-arm64": {
       "version": "1.1.0",


### PR DESCRIPTION
Bumps @pagefind/default-ui from 1.1.0 to 1.1.1.

---
updated-dependencies:
- dependency-name: "@pagefind/default-ui" dependency-type: indirect ...

<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

copilot:summary

## Details

copilot:walkthrough
